### PR TITLE
Implement Swagger API documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ RUN pip install -r requirements.txt
 ADD . /Kasa/
 
 # Install Angular packages
-WORKDIR /Kasa/gui/app
-RUN npm install
+# WORKDIR /Kasa/gui/app
+# RUN npm install
 
 # Expose ports
 EXPOSE 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
- version: '3'
+ version: '2'
  services:
    kasa:
-     restart: unless-stopped
      image: kasa:latest
-     command: python /Kasa/manage.py runserver
+     command: python /Kasa/manage.py runserver 0.0.0.0:8000
      ports:
-       - "8200:8200"
+       - "8000:8000"
      volumes:
        - ".:/Kasa/"

--- a/gui/app/package-lock.json
+++ b/gui/app/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Casa",
+  "name": "Kasa",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/kasa/settings.py
+++ b/kasa/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = ')corm&2xj51bs8za!x5i1ri%2p71=n&tzefvsr)t@e@0d4_@&j'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition

--- a/kasa/settings.py
+++ b/kasa/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework_swagger',
     'api'
 ]
 

--- a/kasa/urls.py
+++ b/kasa/urls.py
@@ -1,4 +1,4 @@
-"""casa URL Configuration
+"""Kasa URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
     https://docs.djangoproject.com/en/1.11/topics/http/urls/
@@ -15,11 +15,17 @@ Including another URLconf
 """
 from django.conf.urls import url
 from django.contrib import admin
+from rest_framework_swagger.views import get_swagger_view
 
 from api.views.index import IndexView
 
+
+schema_view = get_swagger_view(title='Kasa API')
+
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
+
+    url(r'^swagger$', schema_view),
 
     url(r'^$',
         IndexView.as_view(),

--- a/kasa/urls.py
+++ b/kasa/urls.py
@@ -13,21 +13,22 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
+
+
 from django.conf.urls import url
-from django.contrib import admin
+
 from rest_framework_swagger.views import get_swagger_view
+from rest_framework.urlpatterns import format_suffix_patterns
 
 from api.views.index import IndexView
 
 
-schema_view = get_swagger_view(title='Kasa API')
-
-urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-
-    url(r'^swagger$', schema_view),
+urlpatterns = format_suffix_patterns([
+    url(r'^swagger/$',
+        get_swagger_view(
+            title='Kasa API')),
 
     url(r'^$',
         IndexView.as_view(),
         name='index')
-]
+])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 Django==1.11.7
 django-appconf==1.0.2
 django-compressor==2.2
-django-filter==1.1
 djangorestframework==3.7.7
 drf-nested-routers==0.90.0
 future==0.16.0
 requests==2.18.4
+django-rest-swagger==2.1.1


### PR DESCRIPTION
This PR implements Swagger through the use of the Python package `django-rest-swagger`. The Swagger documentation can be found at `<application URL>/swagger/`, which should provide a list of all active API endpoints and the models that should be send and responded by the API endpoints. 

This PR should resolve Issue #2.